### PR TITLE
Tolerate imperfect eSCL servers: accept misspelled AdfState, keep optional fields non-fatal, preserve parse errors

### DIFF
--- a/Sources/SwiftESCL/Enums/AdfState.swift
+++ b/Sources/SwiftESCL/Enums/AdfState.swift
@@ -5,7 +5,7 @@
 //  Created by Leo Wehrfritz on 23.01.25.
 //
 
-public enum AdfState: String {
+public enum AdfState: String, CaseIterable {
     case processing = "ScannerAdfProcessing"
     case empty = "ScannerAdfEmpty"
     case jam = "ScannerAdfJam"
@@ -17,4 +17,15 @@ public enum AdfState: String {
     case multipickDetected = "ScannerAdfMultipickDetected"
     case inputTrayFailed = "ScannerAdfInputTrayFailed"
     case inputTrayOverloaded = "ScannerAdfInputTrayOverloaded"
+
+    public init?(rawValue: String) {
+        // Some widely-deployed servers (NAPS2, for example) emit the
+        // misspelled value "ScannedAdfLoaded" instead of "ScannerAdfLoaded",
+        // so both spellings are accepted here.
+        let normalized = rawValue == "ScannedAdfLoaded" ? "ScannerAdfLoaded" : rawValue
+        guard let match = Self.allCases.first(where: { $0.rawValue == normalized }) else {
+            return nil
+        }
+        self = match
+    }
 }

--- a/Sources/SwiftESCL/EsclScanner.swift
+++ b/Sources/SwiftESCL/EsclScanner.swift
@@ -14,7 +14,7 @@ import OSLog
 open class EsclScanner: Identifiable {
     
     public static let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier!,
+        subsystem: Bundle.main.bundleIdentifier ?? "SwiftESCL",
         category: String(describing: ScannerBrowser.self)
     )
     

--- a/Sources/SwiftESCL/ScannerBrowser.swift
+++ b/Sources/SwiftESCL/ScannerBrowser.swift
@@ -14,7 +14,7 @@ import OSLog
 open class ScannerBrowser: ObservableObject {
     
     private let logger = Logger(
-        subsystem: Bundle.main.bundleIdentifier!,
+        subsystem: Bundle.main.bundleIdentifier ?? "SwiftESCL",
         category: String(describing: ScannerBrowser.self)
     )
     

--- a/Sources/SwiftESCL/XML Helpers/EsclScanImageInfo.swift
+++ b/Sources/SwiftESCL/XML Helpers/EsclScanImageInfo.swift
@@ -68,7 +68,11 @@ public struct EsclScanImageInfo: XMLDecodable {
         }
         
         public func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
-            self.parsingError = parseError
+            // abortParsing() reports NSXMLParserDelegateAbortedParseError here,
+            // which must not overwrite a more descriptive error set by the delegate.
+            if self.parsingError == nil {
+                self.parsingError = parseError
+            }
             parser.abortParsing()
         }
         

--- a/Sources/SwiftESCL/XML Helpers/EsclScanImageInfo.swift
+++ b/Sources/SwiftESCL/XML Helpers/EsclScanImageInfo.swift
@@ -50,7 +50,7 @@ public struct EsclScanImageInfo: XMLDecodable {
     public class ParserDelegate: NSObject, XMLParserDelegate {
         
         static let logger = Logger(
-            subsystem: Bundle.main.bundleIdentifier!,
+            subsystem: Bundle.main.bundleIdentifier ?? "SwiftESCL",
             category: String(describing: ScannerBrowser.self)
         )
         

--- a/Sources/SwiftESCL/XML Helpers/EsclScannerCapabilities.swift
+++ b/Sources/SwiftESCL/XML Helpers/EsclScannerCapabilities.swift
@@ -338,7 +338,11 @@ public struct EsclScannerCapabilities: XMLDecodable {
         
         // For debugging
         public func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
-            self.parsingError = parseError
+            // abortParsing() reports NSXMLParserDelegateAbortedParseError here,
+            // which must not overwrite a more descriptive error set by the delegate.
+            if self.parsingError == nil {
+                self.parsingError = parseError
+            }
             parser.abortParsing()
         }
     }

--- a/Sources/SwiftESCL/XML Helpers/EsclScannerCapabilities.swift
+++ b/Sources/SwiftESCL/XML Helpers/EsclScannerCapabilities.swift
@@ -73,7 +73,7 @@ public struct EsclScannerCapabilities: XMLDecodable {
     public class ParserDelegate: NSObject, XMLParserDelegate {
         
         static let logger = Logger(
-            subsystem: Bundle.main.bundleIdentifier!,
+            subsystem: Bundle.main.bundleIdentifier ?? "SwiftESCL",
             category: String(describing: ParserDelegate.self)
         )
         

--- a/Sources/SwiftESCL/XML Helpers/EsclScannerStatus.swift
+++ b/Sources/SwiftESCL/XML Helpers/EsclScannerStatus.swift
@@ -93,10 +93,11 @@ public struct ScannerStatus: XMLDecodable {
                 }
                 self.scannerStatus?.state = state
             case "adfstate":
+                // AdfState is optional in the status, so an unknown value
+                // shouldn't make the whole document unreadable.
                 guard let adfState = AdfState(rawValue: currentValue) else {
-                    self.parsingError = XMLDecodingError.unexptedType(AdfState.self, currentValue)
-                    parser.abortParsing()
-                    return
+                    Self.logger.warning("Ignoring unknown AdfState \(self.currentValue, privacy: .public)")
+                    break
                 }
                 self.scannerStatus?.adfState = adfState
             case "joburi":

--- a/Sources/SwiftESCL/XML Helpers/EsclScannerStatus.swift
+++ b/Sources/SwiftESCL/XML Helpers/EsclScannerStatus.swift
@@ -69,7 +69,11 @@ public struct ScannerStatus: XMLDecodable {
         }
         
         public func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
-            self.parsingError = parseError
+            // abortParsing() reports NSXMLParserDelegateAbortedParseError here,
+            // which must not overwrite a more descriptive error set by the delegate.
+            if self.parsingError == nil {
+                self.parsingError = parseError
+            }
             parser.abortParsing()
         }
         

--- a/Sources/SwiftESCL/XML Helpers/EsclScannerStatus.swift
+++ b/Sources/SwiftESCL/XML Helpers/EsclScannerStatus.swift
@@ -45,7 +45,7 @@ public struct ScannerStatus: XMLDecodable {
     public class ParserDelegate: NSObject, XMLParserDelegate {
         
         static let logger = Logger(
-            subsystem: Bundle.main.bundleIdentifier!,
+            subsystem: Bundle.main.bundleIdentifier ?? "SwiftESCL",
             category: String(describing: ScannerBrowser.self)
         )
         

--- a/Tests/SwiftESCLTests/XmlParsingTests.swift
+++ b/Tests/SwiftESCLTests/XmlParsingTests.swift
@@ -452,6 +452,35 @@ ORIGIN. -->
     #expect(secondJob.jobState == .processing)
 }
 
+/// Some widely-deployed servers emit the misspelled AdfState value
+/// "ScannedAdfLoaded" instead of "ScannerAdfLoaded".
+/// This fixture was captured from a real NAPS2 8.3.2 eSCL server.
+@Test func decodeScannerStatusWithMisspelledAdfState() async throws {
+    let xmlData = """
+<?xml version="1.0" encoding="UTF-8"?><scan:ScannerStatus xmlns:scan="http://schemas.hp.com/imaging/escl/2011/05/03" xmlns:pwg="http://www.pwg.org/schemas/2010/12/sm">  <pwg:Version>2.6</pwg:Version>  <pwg:State>Idle</pwg:State>  <scan:AdfState>ScannedAdfLoaded</scan:AdfState>  <scan:Jobs /></scan:ScannerStatus>
+""".data(using: .utf8)!
+
+    let scannerStatus = try ScannerStatus(xmlData: xmlData)
+
+    #expect(scannerStatus.version == "2.6")
+    #expect(scannerStatus.state == .idle)
+    #expect(scannerStatus.adfState == .loaded)
+}
+
+/// An unknown value in an optional field like AdfState shouldn't make the whole
+/// status document unreadable.
+@Test func decodeScannerStatusWithUnknownAdfState() async throws {
+    let xmlData = """
+<?xml version="1.0" encoding="UTF-8"?><scan:ScannerStatus xmlns:scan="http://schemas.hp.com/imaging/escl/2011/05/03" xmlns:pwg="http://www.pwg.org/schemas/2010/12/sm">  <pwg:Version>2.6</pwg:Version>  <pwg:State>Idle</pwg:State>  <scan:AdfState>ScannerAdfSomethingUnexpected</scan:AdfState>  <scan:Jobs /></scan:ScannerStatus>
+""".data(using: .utf8)!
+
+    let scannerStatus = try ScannerStatus(xmlData: xmlData)
+
+    #expect(scannerStatus.version == "2.6")
+    #expect(scannerStatus.state == .idle)
+    #expect(scannerStatus.adfState == nil)
+}
+
 @Test func decodeScanImageInfo() async throws {
     let xmlData = """
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

This makes SwiftESCL more tolerant of imperfect but real-world eSCL servers. I ran OpenAirScan against a NAPS2 8.3.2 eSCL server and its status responses were rejected in ways that were hard to diagnose from the app side:

- **Accept the `ScannedAdfLoaded` spelling for `AdfState`**: NAPS2 emits the misspelled value `ScannedAdfLoaded` (instead of `ScannerAdfLoaded`) in its `ScannerStatus` responses, which previously made `AdfState(rawValue:)` fail, so scanning from the ADF broke against these servers. The misspelling has been reported upstream to NAPS2 as well, but it is a widely-deployed server and existing installations won't be updated, so the client now accepts both spellings and normalizes them to `.loaded`. The public API is unchanged (the custom `init?(rawValue:)` keeps the same signature as the synthesized one).
- **Don't abort the whole `ScannerStatus` parse on an unknown `AdfState`**: `AdfState` is an optional element of the status document, so an unrecognized value is now logged and left as `nil` instead of making the entire document unreadable. Required fields such as `State` remain strict.
- **Preserve descriptive parsing errors**: `abortParsing()` re-enters `parseErrorOccurred` with `NSXMLParserDelegateAbortedParseError`, which overwrote the descriptive `XMLDecodingError` the delegates had just set. Callers only ever saw the generic `NSXMLParserErrorDomain error 512` message (this is exactly what OpenAirScan surfaced in its error dialog). The delegates now keep the first error, so strict failures report what was actually wrong. Applied to all three parser delegates.
- **Don't force-unwrap `Bundle.main.bundleIdentifier`**: It is `nil` outside of an app bundle (for example under `swift test`), which crashed the library the moment a logger was touched. The loggers now fall back to `"SwiftESCL"` as the subsystem.

## Testing

- Added two `ScannerStatus` tests: one with the `ScannedAdfLoaded` fixture captured from a live NAPS2 8.3.2 server (expects `.loaded`), and one with an unknown `AdfState` value (expects `nil` instead of a throw).
- `swift build` and `swift test` pass with all 5 tests green on macOS (Swift 6.2.3).
- Verified against the live NAPS2 server that the previously rejected `ScannerStatus` response now decodes.

This also fixes part of the family of issues behind #4 (unusual-but-valid server behavior breaking discovery/scanning); the discovery-side part (adminurl/port handling, #7) is discussed separately in #10.
